### PR TITLE
Update `Coedit` to `Dexed` and fix the repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@
 * [Visual D](https://github.com/dlang/visuald) - Visual Studio extension for the D programming language.
 * [DDT](http://ddt-ide.github.io/) - Eclipse plugin for the D programming language.
 * [DCD](https://github.com/Hackerpilot/DCD) - Independent auto-complete program for the D programming language. Could be used with editors like vim, emacs, sublime text, textadept, and zeus. See [editors support](https://github.com/Hackerpilot/DCD/wiki/IDEs-and-Editors-with-DCD-support).
-* [Coedit](https://github.com/BBasile/Coedit) - IDE for the D programming language, its compilers, tools and libraries.
+* [Dexed](https://github.com/Akira13641/dexed) - IDE for the D programming language, its compilers, tools and libraries.
 * [Dlang IDE](https://github.com/buggins/dlangide) - D language IDE based on [DlangUI](https://github.com/buggins/dlangui). This is a pure D implementation.
 * [D Language Server](https://github.com/d-language-server/dls) - Language Server Protocol (LSP) implementation for D.  Adds modern IDE features to any editor with LSP support (VSCode, Sublime, Atom, Emacs, Vim/Neovim)
 * [Dutyl](https://github.com/idanarye/vim-dutyl) - Vim plugin that integrates various D development tools


### PR DESCRIPTION
The original author of what was originally called `Coedit` changed the name of it to `Dexed` a while ago, and then some time after that abandoned the project entirely. I decided to pick up where he left off, and re-uploaded the repo (which he had deleted along with his Github account) [here](https://github.com/Akira13641/dexed).